### PR TITLE
Add tags when copying forms.

### DIFF
--- a/src/copy.js
+++ b/src/copy.js
@@ -68,6 +68,7 @@ module.exports = function(options, next) {
       (new formio.Project(project)).form(parts[3]).then(function(form) {
         if (form) {
           form.form.components = components;
+          form.form.tags = source.tags;
           form.save().then(function() {
             console.log('Done!');
             next();
@@ -79,6 +80,7 @@ module.exports = function(options, next) {
             name: _.camelCase(parts[3]),
             path: parts[3],
             type: source.type,
+            tags: source.tags,
             components: components
           }).then(function() {
             console.log('Done!');


### PR DESCRIPTION
This PR will add the ability to copy the form tags when copying a form to a new location. Currently the tags are not copying over with the rest of the form.
