### PR TITLE
fix serve to accept CLI parameter correctly

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -10,7 +10,7 @@ module.exports = function(program, next) {
     .option('-p, --port [port]', 'The port you wish to serve the application.')
     .action(series([
       function(options, next) {
-        options.directory = options.param;
+        options.directory = options.params[0];
 
         if (!fs.existsSync(options.directory)) {
           return next('Directory not found');


### PR DESCRIPTION
Hi community, 

Today I tried to start serve but keep encountering "directory not found".  Seems like there is a little bug at the parameter part of code. 

I'm not very familiar with node.js, so if it's not correct way to fix, please feel free to let me know. 

Best, 