### PR TITLE
FIO-7179: fix object mutation that will clobber project settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 8
+    "ecmaVersion": 9
   },
   "rules": {
     "curly": [2, "all"],

--- a/src/Cloner.js
+++ b/src/Cloner.js
@@ -253,7 +253,7 @@ class Cloner {
       try {
         // Create the item we will be inserting/updating.
         const destItem = await this.findLast(`dest.${collection}`, this.findQuery(current, find));
-        const updatedItem = _.assign(destItem || {}, _.omit(srcItem, ['_id']));
+        const updatedItem = {...destItem, ...(_.omit(srcItem, ['_id']))};
 
         // Call before handler and then update if it says we should.
         if (

--- a/src/Cloner.js
+++ b/src/Cloner.js
@@ -740,16 +740,16 @@ class Cloner {
       this.dstSecret = decryptedDstSettings.secret;
     }
 
-    // Do not overwrite existing destination project settings.
-    if (dest && dest['settings_encrypted']) {
-      update['settings_encrypted'] = dest['settings_encrypted'];
-      return;
-    }
-
     // Decrypt the source, and set the update to the re-encrypted settings object.
     const decryptedSrcSettings = this.decrypt(this.options.srcDbSecret, src['settings_encrypted'], true);
     if (decryptedSrcSettings.secret) {
       this.srcSecret = decryptedSrcSettings.secret;
+    }
+
+    // Do not overwrite existing destination project settings.
+    if (dest && dest['settings_encrypted']) {
+      update['settings_encrypted'] = dest['settings_encrypted'];
+      return;
     }
 
     update['settings_encrypted'] = this.encrypt(this.options.dstDbSecret, decryptedSrcSettings, true);


### PR DESCRIPTION
lodash's [assign method](https://lodash.com/docs/4.17.15#assign), like its vanilla counterpart [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), mutates the target object of an operation. In other words,

```
const target = { a: 1, b: 2 };
const source = { b: 4, c: 5 };

const returnedTarget = Object.assign(target, source);

console.log(target);
// outputs Object { a: 1, b: 4, c: 5 }
// i.e. target has been mutated

console.log(returnedTarget === target);
// outputs true
```

When we create the intermediate `updatedItem` item in the CLI during the clone process, we were using the code 
```
const updatedItem = _.assign(destItem || {}, _.omit(srcItem, ['_id']));
```
which will mutate `destItem` (should it exist) and clobber it's properties with identically-named `srcItem` properties. This was causing an issue where running the clone command twice (once when `destItem` doesn't exist, and once when it does) was causing the `destItem` project settings to be overwritten. This PR uses the spread operator to ensure that the top level of the `destItem` object is not mutated when creating the intermediate `updatedItem` object.